### PR TITLE
Bankrupcy and winner

### DIFF
--- a/Gameboard.Designer.cs
+++ b/Gameboard.Designer.cs
@@ -245,6 +245,7 @@ namespace MonopolyGame
             resources.ApplyResources(balanceTextBox, "balanceTextBox");
             balanceTextBox.ForeColor = SystemColors.WindowText;
             balanceTextBox.Name = "balanceTextBox";
+            balanceTextBox.TextChanged += balanceTextBox_TextChanged;
             // 
             // buyButton
             // 

--- a/Gameboard.cs
+++ b/Gameboard.cs
@@ -313,7 +313,7 @@ namespace MonopolyGame
             }
         }
 
-        public void nextTurnButton_Click(object sender, EventArgs e)
+        private void nextTurnButton_Click(object sender, EventArgs e)
         {
             if (players[currentPlayerIndex].getMoneyBalance() >= 0)
             {

--- a/Gameboard.cs
+++ b/Gameboard.cs
@@ -17,7 +17,7 @@ namespace MonopolyGame
         private PropertyList propertyList = new PropertyList();
 
         public int rollCount = 0;
-        int doublesCount = 0;
+        public int doublesCount = 0;
         public Gameboard(List<Player> players)
         {
             InitializeComponent();
@@ -237,7 +237,7 @@ namespace MonopolyGame
 
                 if (currentPlayer.getInJailCounter() == 0)
                 {
-                    gameplay.movePiece(currentPlayer, total, playerPieces, spaces, propertyList);
+                    gameplay.movePiece(currentPlayer, total, playerPieces, spaces, propertyList, this);
 
                     //display property price on buy button
                     if (propertyList.getProperties().TryGetValue(currentPlayer.getBoardPosition(), out Property currentProperty))
@@ -260,7 +260,7 @@ namespace MonopolyGame
                         }
                         else
                         {
-                            gameplay.goToJail(players[currentPlayerIndex], playerPieces, spaces);
+                            gameplay.goToJail(players[currentPlayerIndex], playerPieces, spaces, this);
                         }
                     }
                     else
@@ -313,30 +313,67 @@ namespace MonopolyGame
             }
         }
 
-        private void nextTurnButton_Click(object sender, EventArgs e)
+        public void nextTurnButton_Click(object sender, EventArgs e)
         {
-            if (rollCount > 0)
+            if (players[currentPlayerIndex].getMoneyBalance() >= 0)
             {
-                currentPlayerIndex = (currentPlayerIndex + 1) % players.Count;
+                if (rollCount > 0)
+                {
+                    currentPlayerIndex = (currentPlayerIndex + 1) % players.Count;
+                    string nextPlayerName = players[currentPlayerIndex].getName();
+                    playerLabel.Text = "Player: " + nextPlayerName;
+                    balanceTextBox.Text = "$" + players[currentPlayerIndex].getMoneyBalance();
+                    buyButton.Text = "Buy";
+                    sellButton.Text = "Sell";
+
+                    updateCurrentPlayerProperties();
+
+                    rollCount = 0;
+                    doublesCount = 0;
+                }
+                else if (doublesCount > 0)
+                {
+                    MessageBox.Show("You rolled doubles. You get to roll again!");
+                }
+                else
+                {
+                    MessageBox.Show("Please roll the dice before ending your turn.");
+                }
+            }
+            //Bankrupcy
+            else
+            {
+                MessageBox.Show("You have gone bankrupt. Better luck next time.");
+
+                foreach (Property property in players[currentPlayerIndex].getProperties())
+                {
+                    property.setOwner(null);
+                }
+
+                players.Remove(players[currentPlayerIndex]);
+
+                currentPlayerIndex = (currentPlayerIndex) % players.Count;
                 string nextPlayerName = players[currentPlayerIndex].getName();
                 playerLabel.Text = "Player: " + nextPlayerName;
                 balanceTextBox.Text = "$" + players[currentPlayerIndex].getMoneyBalance();
                 buyButton.Text = "Buy";
                 sellButton.Text = "Sell";
+                nextTurnButton.Text = "Next Turn";
 
                 updateCurrentPlayerProperties();
 
                 rollCount = 0;
                 doublesCount = 0;
+                // Winner
+                if (players.Count() == 1)
+                {
+                    MessageBox.Show("Congradulations You Win!");
+                    StartMenu startMenu = new StartMenu();
+                    this.Hide();
+                    startMenu.Show();
+                }
             }
-            else if (doublesCount > 0)
-            {
-                MessageBox.Show("You rolled doubles. You get to roll again!");
-            }
-            else
-            {
-                MessageBox.Show("Please roll the dice before ending your turn.");
-            }
+
         }
 
         private void buyButton_Click(object sender, EventArgs e)
@@ -573,8 +610,8 @@ namespace MonopolyGame
             if (lastClickedPanel != null && panelToPropertyMap.ContainsKey(lastClickedPanel))
             {
                 Property property = panelToPropertyMap[lastClickedPanel];
-                
-                if(property.getHouseCount() > 0)
+
+                if (property.getHouseCount() > 0)
                 {
                     property.setHouseCount(property.getHouseCount() - 1);
                     players[currentPlayerIndex].setMoneyBalance(players[currentPlayerIndex].getMoneyBalance() + property.getHousePrice());
@@ -582,6 +619,20 @@ namespace MonopolyGame
                     updateCurrentPlayerProperties();
                 }
 
+            }
+        }
+
+        private void balanceTextBox_TextChanged(object sender, EventArgs e)
+        {
+            if (players[currentPlayerIndex].getMoneyBalance() < 0)
+            {
+                balanceTextBox.Text = "$" + players[currentPlayerIndex].getMoneyBalance();
+                MessageBox.Show("You are " + Math.Abs(players[currentPlayerIndex].getMoneyBalance()) + " in debt. You must sell property to avoid bankrupcy");
+                nextTurnButton.Text = "Declare Bankrupcy";
+            }
+            else
+            {
+                nextTurnButton.Text = "Next Turn";
             }
         }
     }

--- a/Gameplay.cs
+++ b/Gameplay.cs
@@ -21,7 +21,7 @@ namespace MonopolyGame
             return (dice1, dice2, total);
         }
 
-        public void movePiece(Player currentPlayer, int total, Dictionary<Player, PictureBox> playerPieces, PictureBox[] spaces, PropertyList propertyList)
+        public void movePiece(Player currentPlayer, int total, Dictionary<Player, PictureBox> playerPieces, PictureBox[] spaces, PropertyList propertyList, Gameboard gameboard)
         {
             int previousBoardPosition = currentPlayer.getBoardPosition();
             int newBoardPosition = (currentPlayer.getBoardPosition() + total) % spaces.Length;
@@ -36,7 +36,7 @@ namespace MonopolyGame
             pieceToMove.Location = new System.Drawing.Point(targetX, targetY);
             currentSpace.Controls.Add(pieceToMove);
             //income tax
-            if(newBoardPosition == 4)
+            if (newBoardPosition == 4)
             {
                 currentPlayer.setMoneyBalance(currentPlayer.getMoneyBalance() - 200);
                 MessageBox.Show("You paid $200 in income tax.");
@@ -50,43 +50,33 @@ namespace MonopolyGame
             //Go to jail
             if (newBoardPosition == 30)
             {
-                goToJail(currentPlayer, playerPieces, spaces);
+                goToJail(currentPlayer, playerPieces, spaces,gameboard);
             }
             // Charge player rent if they land on square owned by other players
             if (propertyList.getProperties().TryGetValue(newBoardPosition, out Property currentProperty))
             {
                 if (currentProperty.getOwner() != null)
                 {
-                    if(currentProperty.getOwner().getPiece() != currentPlayer.getPiece())    
+                    if (currentProperty.getOwner().getPiece() != currentPlayer.getPiece())
                     {
-                        if (currentProperty.getRent(total) < currentPlayer.getMoneyBalance())
-                        {
-                            int rentDue = currentProperty.getRent(total);
-                            currentProperty.getOwner().setMoneyBalance(currentProperty.getOwner().getMoneyBalance() + rentDue);
-                            currentPlayer.setMoneyBalance(currentPlayer.getMoneyBalance() - rentDue);
-                            MessageBox.Show("You paid " + currentProperty.getOwner().getName() + " $" + currentProperty.getRent(total) + " for rent.");
-                        }
-                        else
-                        {
-                            // add bankrupcy logic here
-                        }
+
+                        int rentDue = currentProperty.getRent(total);
+                        currentProperty.getOwner().setMoneyBalance(currentProperty.getOwner().getMoneyBalance() + rentDue);
+                        currentPlayer.setMoneyBalance(currentPlayer.getMoneyBalance() - rentDue);
+                        MessageBox.Show("You paid " + currentProperty.getOwner().getName() + " $" + currentProperty.getRent(total) + " for rent.");
                     }
                 }
             }
-
-
             // pay player for passing go
             if (previousBoardPosition > newBoardPosition)
             {
                 currentPlayer.setMoneyBalance(currentPlayer.getMoneyBalance() + 200);
             }
-
             Cards cards = new Cards();
             //if lands on chest space
             if (currentPlayer.getBoardPosition() == 2 || currentPlayer.getBoardPosition() == 17 || currentPlayer.getBoardPosition() == 33)
             {
                 cards.DrawChestCard(currentPlayer);
-
             }
 
             //if lands on chance space
@@ -94,11 +84,11 @@ namespace MonopolyGame
             {
                 Console.WriteLine("chance");
                 cards.DrawChanceCard(currentPlayer);
-
             }
         }
-        public void goToJail(Player currentPlayer, Dictionary<Player, PictureBox> playerPieces, PictureBox[] spaces)
+        public void goToJail(Player currentPlayer, Dictionary<Player, PictureBox> playerPieces, PictureBox[] spaces, Gameboard gameboard)
         {
+            gameboard.doublesCount = 0;
             MessageBox.Show("Go to Jail!");
 
             int newBoardPosition = (10) % spaces.Length;
@@ -129,7 +119,7 @@ namespace MonopolyGame
                 gameBoard.diceRoll2.BackgroundImage = (Bitmap)Properties.Resources.ResourceManager.GetObject($"dice_{dice2}");
 
                 currentPlayer.setInJailCounter(0);
-                movePiece(currentPlayer, total, playerPieces, spaces, propertyList);
+                movePiece(currentPlayer, total, playerPieces, spaces, propertyList, gameBoard);
             }
             else
             {


### PR DESCRIPTION
Added logic to remove players who run out of money and cannot pay off debts. Added win message when only one player is left and return to start menu. Still need to remove the pieces of losing players from the board they currently sit where they lost until the game is over.